### PR TITLE
build: add watch system for automatic package builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4560,7 +4560,7 @@
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.14",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/puppeteer": {
@@ -4588,7 +4588,7 @@
         },
         "node_modules/@types/react": {
             "version": "18.3.18",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -14345,7 +14345,7 @@
         },
         "node_modules/csstype": {
             "version": "3.1.3",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/data-uri-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,35 @@
         "test": "npm run test --workspaces",
         "lint": "npm run lint --workspaces",
         "lint:fix": "npm run lint:fix --workspaces",
-        "type-check": "npm run type-check --workspaces"
+        "type-check": "npm run type-check --workspaces",
+        "watch": "node scripts/package-monitor.js"
+    },
+    "packageMonitor": {
+        "packages": {
+            "core": {
+                "path": "packages/core",
+                "buildCommand": "npm run build --workspace=@wix-pilot/core"
+            },
+            "web-utils": {
+                "path": "packages/drivers/web-utils",
+                "buildCommand": "npm run build --workspace=@wix-pilot/web-utils"
+            }
+        },
+        "watchPatterns": [
+            "src/**/*.ts",
+            "src/**/*.tsx",
+            "src/**/*.js",
+            "src/**/*.jsx"
+        ],
+        "ignorePatterns": [
+            "**/node_modules/**",
+            "**/dist/**",
+            "**/*.test.ts",
+            "**/*.test.tsx",
+            "**/*.test.js",
+            "**/*.test.jsx"
+        ],
+        "debounceMs": 300
     },
     "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/scripts/PACKAGE-MONITOR.md
+++ b/scripts/PACKAGE-MONITOR.md
@@ -1,0 +1,52 @@
+# Package Monitor
+
+This tool allows you to monitor changes in specific packages of the monorepo and automatically trigger builds when files are modified.
+
+To add more packages to be monitored, add them to the `packageMonitor.packages` section in your `package.json`:
+
+## Usage
+
+From the root of the monorepo, run:
+
+```bash
+npm run watch
+```
+This will run the `package-monitor.js` script, and will start watching all configured packages for changes and trigger builds when files are modified.
+
+## Configuration
+
+All configuration is stored in the root `package.json` file under the `packageMonitor` key.
+
+### Customizing Watch Patterns
+
+You can customize which files are watched by editing the `watchPatterns` array in the `packageMonitor` section:
+
+```json
+"watchPatterns": [
+  "src/**/*.ts",
+  "src/**/*.tsx", 
+  "lib/**/*.js"
+]
+```
+
+### Customizing Ignore Patterns
+
+To exclude certain files or directories from being watched, edit the `ignorePatterns` array:
+
+```json
+"ignorePatterns": [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/*.spec.ts"
+]
+```
+
+### Adjusting Debounce Time
+
+You can adjust how long the system waits after a file change before triggering a build:
+
+```json
+"debounceMs": 500
+```
+
+This will wait 500ms after changes before building.

--- a/scripts/package-monitor.js
+++ b/scripts/package-monitor.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+// See PACKAGE-MONITOR.md for usage instructions
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const chokidar = require('chokidar');
+
+// Read configuration from package.json
+const rootDir = path.join(__dirname, '..');
+const packageJsonPath = path.join(rootDir, 'package.json');
+
+// Load package.json and extract configuration
+let packageJson;
+try {
+  packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+} catch (error) {
+  console.error('Failed to read package.json:', error.message);
+  process.exit(1);
+}
+
+// Extract package monitor config
+const config = packageJson.packageMonitor || {};
+const packagesToMonitor = {};
+
+// Process packages from config
+if (config.packages) {
+  Object.entries(config.packages).forEach(([name, pkgConfig]) => {
+    packagesToMonitor[name] = {
+      path: path.join(rootDir, pkgConfig.path),
+      buildCommand: pkgConfig.buildCommand
+    };
+  });
+}
+
+// If no packages are configured, exit with an error
+if (Object.keys(packagesToMonitor).length === 0) {
+  console.error('No packages configured for monitoring in package.json');
+  console.error('Please add configuration to the "packageMonitor.packages" section:');
+  console.error(`
+  "packageMonitor": {
+    "packages": {
+      "example-package": {
+        "path": "packages/example-package",
+        "buildCommand": "npm run build --workspace=@scope/example-package"
+      }
+    }
+  }`);
+  process.exit(1);
+}
+
+// Get watch and ignore patterns from config
+const watchPatterns = config.watchPatterns;
+
+if (!watchPatterns) {
+  console.error('No watch patterns configured in package.json');
+  console.error('Please add configuration to the "packageMonitor.watchPatterns" section:');
+  console.error(`
+  "packageMonitor": {
+    "watchPatterns": ["src/**/*.ts", "src/**/*.tsx"]
+  }`);
+  process.exit(1);
+}
+
+const ignorePatterns = config.ignorePatterns;
+
+if (!ignorePatterns) {
+  console.error('No ignore patterns configured in package.json');
+  console.error('Please add configuration to the "packageMonitor.ignorePatterns" section:');
+  console.error(`
+  "packageMonitor": {
+    "ignorePatterns": ["**/node_modules/**", "**/dist/**"]
+  }`);
+  process.exit(1);
+}
+
+// Get debounce time from config
+const debounceMs = config.debounceMs;
+
+if (!debounceMs) {
+  console.error('No debounce time configured in package.json');
+  console.error('Please add configuration to the "packageMonitor.debounceMs" section:');
+  console.error(`
+  "packageMonitor": {
+    "debounceMs": 1000
+  }`);
+  process.exit(1);
+}
+
+// Build a specific package
+function buildPackage(packageName, packageConfig) {
+  console.log(`\nBuilding package: ${packageName}...`);
+  try {
+    execSync(packageConfig.buildCommand, { stdio: 'inherit' });
+    console.log(`\n✅ Successfully built ${packageName}`);
+  } catch (error) {
+    console.error(`\n❌ Failed to build ${packageName}:`, error.message);
+  }
+}
+
+// Build all configured packages
+function buildAllPackages() {
+  Object.entries(packagesToMonitor).forEach(([name, config]) => {
+    buildPackage(name, config);
+  });
+}
+
+// Watch packages for changes
+function watchPackages() {
+  Object.entries(packagesToMonitor).forEach(([packageName, packageConfig]) => {
+    console.log(`Watching ${packageName} at ${packageConfig.path}...`);
+
+    // Set up watch patterns
+    const watchPaths = watchPatterns.map(pattern =>
+     path.join(packageConfig.path, pattern)
+    );
+
+    // Set up watcher
+    const watcher = chokidar.watch(watchPaths, {
+      ignored: ignorePatterns,
+      persistent: true
+    });
+
+    // Build on changes
+    let debounceTimer;
+    watcher.on('change', (filePath) => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        console.log(`\nChange detected in ${packageName}: ${path.relative(packageConfig.path, filePath)}`);
+        buildPackage(packageName, packageConfig);
+      }, debounceMs);
+    });
+  });
+
+  console.log('\n👀 Watching for changes. Press Ctrl+C to exit.');
+}
+
+// Main execution
+async function main() {
+  // Install chokidar if not already installed
+  try {
+    require.resolve('chokidar');
+  } catch (e) {
+    console.log('Installing required dependencies...');
+    execSync('npm install --no-save chokidar', { stdio: 'inherit' });
+    console.log('Dependencies installed.');
+  }
+
+  // Always run initial build first
+  buildAllPackages();
+  console.log('\nInitial build completed. Starting watch mode...');
+
+  // Always watch for changes
+  watchPackages();
+}
+
+main().catch(error => {
+  console.error('Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a package monitoring script that reads config from `package.json` and
 watches source files for changes and triggers builds automatically.

Configured via `packageMonitor` section in `package.json`.

See `scripts/PACKAGE-MONITOR.md` for usage details.