### PR TITLE
fix(snapshot): store snapshots on the OS temp-dir.

### DIFF
--- a/packages/drivers/appium/index.ts
+++ b/packages/drivers/appium/index.ts
@@ -6,6 +6,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import { waitForStableState } from "./utils/getStableViewHierarchy";
+import os from "os";
 
 export class WebdriverIOAppiumFrameworkDriver
   implements TestingFrameworkDriver
@@ -38,7 +39,7 @@ export class WebdriverIOAppiumFrameworkDriver
    * Returns the path to the saved screenshot if successful, or undefined otherwise.
    */
   async captureSnapshotImage(_: boolean): Promise<string | undefined> {
-    const tempDir = "temp";
+    const tempDir = path.resolve(os.tmpdir(), "pilot-snapshot");
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir);
     }

--- a/packages/drivers/detox/index.ts
+++ b/packages/drivers/detox/index.ts
@@ -7,6 +7,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { expect as jestExpect } from "expect";
+import os from "os";
 
 /**
  * Pilot driver for the Detox testing framework.
@@ -50,15 +51,16 @@ export class DetoxFrameworkDriver implements TestingFrameworkDriver {
   }
 
   async captureSnapshotImage(_: boolean): Promise<string | undefined> {
-    const tempDir = "temp";
+    const tempDir = path.resolve(os.tmpdir(), "pilot-snapshot");
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir);
     }
 
-    const fileName = `snapshot_detox_${Date.now()}.png`;
+    const fileName = `snapshot_detox_${Date.now()}`;
     try {
       const screenshotPath = await this.detox.device.takeScreenshot(fileName);
-      const tempPath = path.join(tempDir, fileName);
+      const screenshotFileName = path.basename(screenshotPath);
+      const tempPath = path.join(tempDir, screenshotFileName);
       fs.renameSync(screenshotPath, tempPath);
       return tempPath;
     } catch (_error) {

--- a/packages/drivers/web-utils/src/index.ts
+++ b/packages/drivers/web-utils/src/index.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { Page } from "./types";
 import { ELEMENT_MATCHING_CONFIG } from "./matchingConfig";
+import os from "os";
 type AttributeKey = keyof typeof ELEMENT_MATCHING_CONFIG;
 export type ElementMatchingCriteria = {
   [K in AttributeKey]?: ReturnType<
@@ -118,7 +119,7 @@ export default class WebTestingFrameworkDriverHelper {
       return undefined;
     }
 
-    const tempDir = "temp";
+    const tempDir = path.resolve(os.tmpdir(), "pilot-snapshot");
     const fileName = `snapshot_${Date.now()}.png`;
     const filePath = path.resolve(tempDir, fileName);
 


### PR DESCRIPTION
Storing on a local dir requires from others to add the `temp` dir under their `.gitignore` otherwise they will experience spam of images. Storing the images under the OS temp dir solves it.