### PR TITLE
fix(cache): load on perform.

### DIFF
--- a/packages/core/src/Pilot.ts
+++ b/packages/core/src/Pilot.ts
@@ -119,7 +119,6 @@ export class Pilot {
     this.previousSteps = [];
 
     this.cacheHandler.clearTemporaryCache();
-    this.cacheHandler.loadCacheFromFile();
   }
 
   /**
@@ -171,6 +170,8 @@ export class Pilot {
    * @returns The result of the last executed step.
    */
   async perform(...steps: string[]): Promise<any> {
+    this.loadCache();
+
     let result;
     for await (const step of steps) {
       result = await this.performStep(step);
@@ -211,7 +212,15 @@ export class Pilot {
    * @returns pilot report with info about the actions thoughts etc ...
    */
   async autopilot(goal: string): Promise<AutoReport> {
+    this.loadCache();
     this.assertIsRunning();
     return await this.autoPerformer.perform(goal);
+  }
+
+  /**
+   * Loads the cache from the cache file.
+   */
+  private loadCache(): void {
+    this.cacheHandler.loadCacheFromFile();
   }
 }

--- a/packages/core/src/common/cacheHandler/testEnvUtils.ts
+++ b/packages/core/src/common/cacheHandler/testEnvUtils.ts
@@ -7,10 +7,10 @@
  * @returns The current Jest test file path, or undefined if not in Jest or the path is not available
  */
 export function getCurrentTestFilePath(): string | undefined {
-  return getCurrentJestTestFilePathFrom() || getCurrentTestFileFromStackTrace();
+  return getCurrentJestTestFilePath() || getCurrentTestFileFromStackTrace();
 }
 
-function getCurrentJestTestFilePathFrom(): string | undefined {
+function getCurrentJestTestFilePath(): string | undefined {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { expect } = require("expect");


### PR DESCRIPTION
`start()` might be called outside of a test scope (e.g. test-start hook). `perform()` / `autopilot()` has to be called inside a test, this way it's possible to load the test-specific cache file from that point.