### PR TITLE
feat(prompt): improve prompt generation

### DIFF
--- a/packages/core/src/integration-tests/__snapshots__/index.test.ts.snap
+++ b/packages/core/src/integration-tests/__snapshots__/index.test.ts.snap
@@ -42,23 +42,25 @@ Element not found
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "Tap on a non-existent button". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "Tap on a non-existent button". The code should include appropriate synchronization using the testing framework's wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.
 2. When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.
-3. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
-4. Determine if the intent can be fully validated visually using the snapshot image.
-5. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
-6. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
-7. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
-8. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
-9. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-10. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
-11. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
-12. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
-13. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.
+5. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
+6. Determine if the intent can be fully validated visually using the snapshot image.
+7. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
+8. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
+9. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
+10. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+11. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+12. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+13. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+14. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+15. Do not provide any additional code beyond the minimal executable code required to perform the intent.
 
 ### Verify the prompt
 

--- a/packages/core/src/performers/step-performer/StepPerformerPromptCreator.test.ts
+++ b/packages/core/src/performers/step-performer/StepPerformerPromptCreator.test.ts
@@ -190,6 +190,140 @@ describe("PromptCreator", () => {
     expect(prompt).toMatchSnapshot();
   });
 
+  describe("CACHE_VALIDATION_MATCHER behavior", () => {
+    it("should include CACHE_VALIDATION_MATCHER instructions when snapshot is attached", () => {
+      const intent = "tap submit button";
+      const viewHierarchy =
+        '<View><Button testID="submit" title="Submit" /></View>';
+
+      const prompt = promptCreator.createPrompt(
+        intent,
+        viewHierarchy,
+        true,
+        [],
+      );
+
+      expect(prompt).toContain("CACHE_VALIDATION_MATCHER");
+      expect(prompt).toContain(
+        "add code lines that verify the existence of the elements",
+      );
+      expect(prompt).toContain(
+        "This validation matcher will be used in subsequent test executions",
+      );
+      expect(prompt).toMatchSnapshot();
+    });
+
+    it("should NOT include CACHE_VALIDATION_MATCHER instructions when no snapshot is attached", () => {
+      const intent = "tap submit button";
+      const viewHierarchy =
+        '<View><Button testID="submit" title="Submit" /></View>';
+
+      const prompt = promptCreator.createPrompt(
+        intent,
+        viewHierarchy,
+        false,
+        [],
+      );
+
+      expect(prompt).not.toContain("CACHE_VALIDATION_MATCHER");
+      expect(prompt).not.toContain(
+        "add code lines that verify the existence of the elements",
+      );
+      expect(prompt).not.toContain(
+        "This validation matcher will be used in subsequent test executions",
+      );
+      expect(prompt).toMatchSnapshot();
+    });
+  });
+
+  describe("Framework-specific references", () => {
+    it("should use specific framework name when available", () => {
+      const mockAPIWithName: TestingFrameworkAPICatalog = {
+        name: "Playwright",
+        description: "End-to-end testing framework",
+        context: {},
+        categories: mockAPI.categories,
+      };
+
+      const promptCreatorWithName = new StepPerformerPromptCreator(
+        mockAPIWithName,
+      );
+      const intent = "click button";
+      const viewHierarchy =
+        '<View><Button testID="submit" title="Submit" /></View>';
+
+      const prompt = promptCreatorWithName.createPrompt(
+        intent,
+        viewHierarchy,
+        true,
+        [],
+      );
+
+      expect(prompt).toContain("using Playwright");
+      expect(prompt).toContain("Playwright's wait methods");
+      expect(prompt).toContain("Playwright's documented wait APIs");
+      expect(prompt).toContain("Use the provided Playwright APIs");
+      expect(prompt).toContain("Available Playwright API");
+      expect(prompt).toMatchSnapshot();
+    });
+
+    it("should use generic references when no framework name is provided", () => {
+      const intent = "click button";
+      const viewHierarchy =
+        '<View><Button testID="submit" title="Submit" /></View>';
+
+      const prompt = promptCreator.createPrompt(
+        intent,
+        viewHierarchy,
+        true,
+        [],
+      );
+
+      expect(prompt).toContain("using the mentioned testing framework");
+      expect(prompt).toContain("the testing framework's wait methods");
+      expect(prompt).toContain("the testing framework's documented wait APIs");
+      expect(prompt).toContain("Use the provided the testing framework APIs");
+      expect(prompt).toContain("Available Testing Framework API");
+      expect(prompt).toMatchSnapshot();
+    });
+  });
+
+  describe("Synchronization instructions", () => {
+    it("should include synchronization instructions for both scenarios", () => {
+      const intent = "tap button";
+      const viewHierarchy =
+        '<View><Button testID="submit" title="Submit" /></View>';
+
+      // With screenshot
+      const promptWithSnapshot = promptCreator.createPrompt(
+        intent,
+        viewHierarchy,
+        true,
+        [],
+      );
+      expect(promptWithSnapshot).toContain(
+        "Include appropriate synchronization",
+      );
+      expect(promptWithSnapshot).toContain(
+        "wait methods to ensure elements are present",
+      );
+
+      // Without screenshot
+      const promptWithoutSnapshot = promptCreator.createPrompt(
+        intent,
+        viewHierarchy,
+        false,
+        [],
+      );
+      expect(promptWithoutSnapshot).toContain(
+        "Include appropriate synchronization",
+      );
+      expect(promptWithoutSnapshot).toContain(
+        "wait methods to ensure elements are present",
+      );
+    });
+  });
+
   describe("extentAPICategories", () => {
     const intent = "expect button to be visible";
     const viewHierarchy =

--- a/packages/core/src/performers/step-performer/StepPerformerPromptCreator.ts
+++ b/packages/core/src/performers/step-performer/StepPerformerPromptCreator.ts
@@ -73,10 +73,13 @@ export class StepPerformerPromptCreator {
   }
 
   private createBasePrompt(): string[] {
+    const frameworkName =
+      this.apiCatalog.name || "the mentioned testing framework";
+
     const basePrompt = [
       "# Test Code Generation",
       "",
-      "You are an AI assistant tasked with generating test code for a specific test step using the mentioned testing framework.",
+      `You are an AI assistant tasked with generating test code for a specific test step using ${frameworkName}.`,
       "Generate the minimal executable code to perform the desired intent, based on the provided step and context.",
       "",
     ];
@@ -165,7 +168,9 @@ export class StepPerformerPromptCreator {
 
   private createAPIInfo(): string[] {
     return [
-      "## Available Testing Framework API",
+      this.apiCatalog.name
+        ? `## Available ${this.apiCatalog.name} API`
+        : "## Available Testing Framework API",
       "",
       this.apiFormatter.formatAPIInfo(),
     ];
@@ -175,10 +180,20 @@ export class StepPerformerPromptCreator {
     intent: string,
     isSnapshotImageAttached: boolean,
   ): string[] {
-    return [
-      "## Instructions",
-      "",
-      `Your task is to generate the minimal executable code to perform the following intent: "${intent}". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.`,
+    const instructions = ["## Instructions", ""];
+    const frameworkName = this.apiCatalog.name || "the testing framework";
+
+    if (isSnapshotImageAttached) {
+      instructions.push(
+        `Your task is to generate the minimal executable code to perform the following intent: "${intent}". The code should include appropriate synchronization using ${frameworkName}'s wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.`,
+      );
+    } else {
+      instructions.push(
+        `Your task is to generate the minimal executable code to perform the following intent: "${intent}".`,
+      );
+    }
+
+    instructions.push(
       "",
       "Please follow these steps carefully:",
       "",
@@ -197,11 +212,18 @@ export class StepPerformerPromptCreator {
       "throw new Error(\"Unable to find the 'Submit' button element in the current context.\");",
       "</CODE>",
       "",
-      "#### Example of providing the validation matcher",
-      "<CACHE_VALIDATION_MATCHER>",
-      `const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();`,
-      "</CACHE_VALIDATION_MATCHER>",
-    ]
+    );
+
+    if (isSnapshotImageAttached) {
+      instructions.push(
+        "#### Example of providing the validation matcher",
+        "<CACHE_VALIDATION_MATCHER>",
+        `const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();`,
+        "</CACHE_VALIDATION_MATCHER>",
+      );
+    }
+
+    return instructions
       .concat(
         isSnapshotImageAttached
           ? [
@@ -220,10 +242,14 @@ export class StepPerformerPromptCreator {
     isSnapshotImageAttached: boolean,
   ): string[] {
     const steps = [];
+    const frameworkName = this.apiCatalog.name || "the testing framework";
+
     if (isSnapshotImageAttached) {
       steps.push(
         "Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.",
         "When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.",
+        `Include appropriate synchronization in your code using ${frameworkName}'s wait methods to ensure elements are present and ready before interacting with them. Use ${frameworkName}'s documented wait APIs to make the test more reliable and prevent flaky failures.`,
+        "The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.",
         "Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.",
         "Determine if the intent can be fully validated visually using the snapshot image.",
         "If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.",
@@ -234,13 +260,13 @@ export class StepPerformerPromptCreator {
       steps.push(
         "Analyze the provided intent and the view hierarchy to understand the required action.",
         "Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.",
-        "Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.",
+        `Include appropriate synchronization in your code using ${frameworkName}'s wait methods to ensure elements are present and ready before interacting with them. Use ${frameworkName}'s documented wait APIs to make the test more reliable and prevent flaky failures.`,
       );
     }
     steps.push(
       "If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.",
       "Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.",
-      "Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.",
+      `Use the provided ${frameworkName} APIs as much as possible - prefer using the documented API methods over creating custom implementations.`,
       "If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'",
       "Wrap the generated code with <CODE></CODE> block, without any additional formatting.",
       "Do not provide any additional code beyond the minimal executable code required to perform the intent.",

--- a/packages/core/src/performers/step-performer/__snapshots__/StepPerformerPromptCreator.test.ts.snap
+++ b/packages/core/src/performers/step-performer/__snapshots__/StepPerformerPromptCreator.test.ts.snap
@@ -1,9 +1,528 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PromptCreator constructor should merge redundant categories 1`] = `
+exports[`PromptCreator CACHE_VALIDATION_MATCHER behavior should NOT include CACHE_VALIDATION_MATCHER instructions when no snapshot is attached 1`] = `
 "# Test Code Generation
 
 You are an AI assistant tasked with generating test code for a specific test step using the mentioned testing framework.
+Generate the minimal executable code to perform the desired intent, based on the provided step and context.
+
+## Context
+
+### Intent to perform
+
+Generate the minimal executable code to perform the following intent: "tap submit button"
+
+### View hierarchy
+
+This is the complete view hierarchy. Use only the relevant parts for the executable code.
+\`\`\`
+<View><Button testID="submit" title="Submit" /></View>
+\`\`\`
+
+### Snapshot image
+
+No snapshot image is attached for this intent.
+
+## Available Testing Framework API
+
+### Actions
+
+#### tap(element: Element)
+
+Taps on the specified element.
+
+##### Example
+
+\`\`\`
+await element(by.id("button")).tap();
+\`\`\`
+
+##### Guidelines
+
+- Ensure the element is tappable before using this method.
+
+#### typeText(element: Element, text: string)
+
+Types the specified text into the element.
+
+##### Example
+
+\`\`\`
+await element(by.id("input")).typeText("Hello, World!");
+\`\`\`
+
+##### Guidelines
+
+- Use this method only on text input elements.
+
+### Assertions
+
+#### toBeVisible()
+
+Asserts that the element is visible on the screen.
+
+##### Example
+
+\`\`\`
+await expect(element(by.id("title"))).toBeVisible();
+\`\`\`
+
+##### Guidelines
+
+- Consider scroll position when using this assertion.
+
+### Matchers
+
+#### by.id(id: string)
+
+Matches elements by their ID attribute.
+
+##### Example
+
+\`\`\`
+element(by.id("uniqueId"))
+\`\`\`
+
+##### Guidelines
+
+- Use unique IDs for elements to avoid conflicts, combine with atIndex() if necessary.
+
+## Instructions
+
+Your task is to generate the minimal executable code to perform the following intent: "tap submit button".
+
+Please follow these steps carefully:
+
+1. Analyze the provided intent and the view hierarchy to understand the required action.
+2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+
+### Verify the prompt
+
+Before generating the code, please review the provided context and instructions to ensure they are clear and unambiguous. If you encounter any issues or have questions, please throw an informative error explaining the problem.
+
+### Examples
+
+#### Example of throwing an informative error:
+<CODE>
+throw new Error("Unable to find the 'Submit' button element in the current context.");
+</CODE>
+
+Please provide your code below:"
+`;
+
+exports[`PromptCreator CACHE_VALIDATION_MATCHER behavior should include CACHE_VALIDATION_MATCHER instructions when snapshot is attached 1`] = `
+"# Test Code Generation
+
+You are an AI assistant tasked with generating test code for a specific test step using the mentioned testing framework.
+Generate the minimal executable code to perform the desired intent, based on the provided step and context.
+
+## Context
+
+### Intent to perform
+
+Generate the minimal executable code to perform the following intent: "tap submit button"
+
+### View hierarchy
+
+This is the complete view hierarchy. Use only the relevant parts for the executable code.
+\`\`\`
+<View><Button testID="submit" title="Submit" /></View>
+\`\`\`
+
+### Snapshot image
+
+A snapshot image is attached for visual reference.
+
+## Available Testing Framework API
+
+### Actions
+
+#### tap(element: Element)
+
+Taps on the specified element.
+
+##### Example
+
+\`\`\`
+await element(by.id("button")).tap();
+\`\`\`
+
+##### Guidelines
+
+- Ensure the element is tappable before using this method.
+
+#### typeText(element: Element, text: string)
+
+Types the specified text into the element.
+
+##### Example
+
+\`\`\`
+await element(by.id("input")).typeText("Hello, World!");
+\`\`\`
+
+##### Guidelines
+
+- Use this method only on text input elements.
+
+### Assertions
+
+#### toBeVisible()
+
+Asserts that the element is visible on the screen.
+
+##### Example
+
+\`\`\`
+await expect(element(by.id("title"))).toBeVisible();
+\`\`\`
+
+##### Guidelines
+
+- Consider scroll position when using this assertion.
+
+### Matchers
+
+#### by.id(id: string)
+
+Matches elements by their ID attribute.
+
+##### Example
+
+\`\`\`
+element(by.id("uniqueId"))
+\`\`\`
+
+##### Guidelines
+
+- Use unique IDs for elements to avoid conflicts, combine with atIndex() if necessary.
+
+## Instructions
+
+Your task is to generate the minimal executable code to perform the following intent: "tap submit button". The code should include appropriate synchronization using the testing framework's wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.
+
+Please follow these steps carefully:
+
+1. Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.
+2. When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.
+5. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
+6. Determine if the intent can be fully validated visually using the snapshot image.
+7. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
+8. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
+9. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
+10. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+11. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+12. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+13. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+14. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+15. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+
+### Verify the prompt
+
+Before generating the code, please review the provided context and instructions to ensure they are clear and unambiguous. If you encounter any issues or have questions, please throw an informative error explaining the problem.
+
+### Examples
+
+#### Example of throwing an informative error:
+<CODE>
+throw new Error("Unable to find the 'Submit' button element in the current context.");
+</CODE>
+
+#### Example of providing the validation matcher
+<CACHE_VALIDATION_MATCHER>
+const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
+</CACHE_VALIDATION_MATCHER>
+#### Visual validation using the snapshot:
+\`\`\`typescript
+// Visual assertion passed based on the snapshot image.
+\`\`\`
+
+Please provide your code below:"
+`;
+
+exports[`PromptCreator Framework-specific references should use generic references when no framework name is provided 1`] = `
+"# Test Code Generation
+
+You are an AI assistant tasked with generating test code for a specific test step using the mentioned testing framework.
+Generate the minimal executable code to perform the desired intent, based on the provided step and context.
+
+## Context
+
+### Intent to perform
+
+Generate the minimal executable code to perform the following intent: "click button"
+
+### View hierarchy
+
+This is the complete view hierarchy. Use only the relevant parts for the executable code.
+\`\`\`
+<View><Button testID="submit" title="Submit" /></View>
+\`\`\`
+
+### Snapshot image
+
+A snapshot image is attached for visual reference.
+
+## Available Testing Framework API
+
+### Actions
+
+#### tap(element: Element)
+
+Taps on the specified element.
+
+##### Example
+
+\`\`\`
+await element(by.id("button")).tap();
+\`\`\`
+
+##### Guidelines
+
+- Ensure the element is tappable before using this method.
+
+#### typeText(element: Element, text: string)
+
+Types the specified text into the element.
+
+##### Example
+
+\`\`\`
+await element(by.id("input")).typeText("Hello, World!");
+\`\`\`
+
+##### Guidelines
+
+- Use this method only on text input elements.
+
+### Assertions
+
+#### toBeVisible()
+
+Asserts that the element is visible on the screen.
+
+##### Example
+
+\`\`\`
+await expect(element(by.id("title"))).toBeVisible();
+\`\`\`
+
+##### Guidelines
+
+- Consider scroll position when using this assertion.
+
+### Matchers
+
+#### by.id(id: string)
+
+Matches elements by their ID attribute.
+
+##### Example
+
+\`\`\`
+element(by.id("uniqueId"))
+\`\`\`
+
+##### Guidelines
+
+- Use unique IDs for elements to avoid conflicts, combine with atIndex() if necessary.
+
+## Instructions
+
+Your task is to generate the minimal executable code to perform the following intent: "click button". The code should include appropriate synchronization using the testing framework's wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.
+
+Please follow these steps carefully:
+
+1. Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.
+2. When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.
+5. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
+6. Determine if the intent can be fully validated visually using the snapshot image.
+7. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
+8. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
+9. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
+10. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+11. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+12. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+13. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+14. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+15. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+
+### Verify the prompt
+
+Before generating the code, please review the provided context and instructions to ensure they are clear and unambiguous. If you encounter any issues or have questions, please throw an informative error explaining the problem.
+
+### Examples
+
+#### Example of throwing an informative error:
+<CODE>
+throw new Error("Unable to find the 'Submit' button element in the current context.");
+</CODE>
+
+#### Example of providing the validation matcher
+<CACHE_VALIDATION_MATCHER>
+const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
+</CACHE_VALIDATION_MATCHER>
+#### Visual validation using the snapshot:
+\`\`\`typescript
+// Visual assertion passed based on the snapshot image.
+\`\`\`
+
+Please provide your code below:"
+`;
+
+exports[`PromptCreator Framework-specific references should use specific framework name when available 1`] = `
+"# Test Code Generation
+
+You are an AI assistant tasked with generating test code for a specific test step using Playwright.
+Generate the minimal executable code to perform the desired intent, based on the provided step and context.
+
+## Testing Framework
+
+Framework: Playwright
+
+Description: End-to-end testing framework
+
+## Context
+
+### Intent to perform
+
+Generate the minimal executable code to perform the following intent: "click button"
+
+### View hierarchy
+
+This is the complete view hierarchy. Use only the relevant parts for the executable code.
+\`\`\`
+<View><Button testID="submit" title="Submit" /></View>
+\`\`\`
+
+### Snapshot image
+
+A snapshot image is attached for visual reference.
+
+## Available Playwright API
+
+### Actions
+
+#### tap(element: Element)
+
+Taps on the specified element.
+
+##### Example
+
+\`\`\`
+await element(by.id("button")).tap();
+\`\`\`
+
+##### Guidelines
+
+- Ensure the element is tappable before using this method.
+
+#### typeText(element: Element, text: string)
+
+Types the specified text into the element.
+
+##### Example
+
+\`\`\`
+await element(by.id("input")).typeText("Hello, World!");
+\`\`\`
+
+##### Guidelines
+
+- Use this method only on text input elements.
+
+### Assertions
+
+#### toBeVisible()
+
+Asserts that the element is visible on the screen.
+
+##### Example
+
+\`\`\`
+await expect(element(by.id("title"))).toBeVisible();
+\`\`\`
+
+##### Guidelines
+
+- Consider scroll position when using this assertion.
+
+### Matchers
+
+#### by.id(id: string)
+
+Matches elements by their ID attribute.
+
+##### Example
+
+\`\`\`
+element(by.id("uniqueId"))
+\`\`\`
+
+##### Guidelines
+
+- Use unique IDs for elements to avoid conflicts, combine with atIndex() if necessary.
+
+## Instructions
+
+Your task is to generate the minimal executable code to perform the following intent: "click button". The code should include appropriate synchronization using Playwright's wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.
+
+Please follow these steps carefully:
+
+1. Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.
+2. When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.
+3. Include appropriate synchronization in your code using Playwright's wait methods to ensure elements are present and ready before interacting with them. Use Playwright's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.
+5. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
+6. Determine if the intent can be fully validated visually using the snapshot image.
+7. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
+8. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
+9. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
+10. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+11. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+12. Use the provided Playwright APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+13. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+14. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+15. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+
+### Verify the prompt
+
+Before generating the code, please review the provided context and instructions to ensure they are clear and unambiguous. If you encounter any issues or have questions, please throw an informative error explaining the problem.
+
+### Examples
+
+#### Example of throwing an informative error:
+<CODE>
+throw new Error("Unable to find the 'Submit' button element in the current context.");
+</CODE>
+
+#### Example of providing the validation matcher
+<CACHE_VALIDATION_MATCHER>
+const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
+</CACHE_VALIDATION_MATCHER>
+#### Visual validation using the snapshot:
+\`\`\`typescript
+// Visual assertion passed based on the snapshot image.
+\`\`\`
+
+Please provide your code below:"
+`;
+
+exports[`PromptCreator constructor should merge redundant categories 1`] = `
+"# Test Code Generation
+
+You are an AI assistant tasked with generating test code for a specific test step using Test Framework.
 Generate the minimal executable code to perform the desired intent, based on the provided step and context.
 
 ## Testing Framework
@@ -29,7 +548,7 @@ This is the complete view hierarchy. Use only the relevant parts for the executa
 
 No snapshot image is attached for this intent.
 
-## Available Testing Framework API
+## Available Test Framework API
 
 ### Actions
 
@@ -123,16 +642,16 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using Test Framework's wait methods to ensure elements are present and ready before interacting with them. Use Test Framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided Test Framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -148,10 +667,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -260,16 +775,16 @@ await swipe("up");
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -285,10 +800,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -411,16 +922,16 @@ await swipe("up");
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -436,10 +947,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -532,23 +1039,25 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "tap button". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "tap button". The code should include appropriate synchronization using the testing framework's wait methods to ensure reliable test execution. In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This validation matcher will be used in subsequent test executions to wait for the elements to appear on the screen.
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent, the view hierarchy, and the snapshot image to understand the required action.
 2. When interacting with an element, ensure that you use the correct identifier from the view hierarchy. Do not rely on a screenshot to guess the element's selectors. Add code lines that verify the existence of the elements that will be interacted with in this step inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>.
-3. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
-4. Determine if the intent can be fully validated visually using the snapshot image.
-5. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
-6. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
-7. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
-8. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
-9. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-10. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
-11. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
-12. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
-13. Do not provide any additional code beyond the minimal executable code required to perform the intent.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
+4. The code inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER> will be cached and used in future test runs to quickly verify that the page is in the expected state before executing the main test logic.
+5. Assess the positions of elements within the screen layout. Ensure that tests accurately reflect their intended locations, such as whether an element is centered or positioned relative to others. Tests should fail if the actual locations do not align with the expected configuration.
+6. Determine if the intent can be fully validated visually using the snapshot image.
+7. If the intent can be visually analyzed and passes the visual check, return only comments explaining the successful visual assertion.
+8. If the visual assertion fails, return code that throws an informative error explaining the failure, inside <CODE></CODE> block.
+9. If visual validation is not possible, proceed to generate the minimal executable code required to perform the intent.
+10. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
+11. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
+12. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+13. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
+14. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
+15. Do not provide any additional code beyond the minimal executable code required to perform the intent.
 
 ### Verify the prompt
 
@@ -662,16 +1171,16 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "expect button to be visible".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -687,10 +1196,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -805,16 +1310,16 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "tap button". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "tap button".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -830,10 +1335,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -945,16 +1446,16 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "tap button". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "tap button".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -970,10 +1471,6 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;
 
@@ -1093,16 +1590,16 @@ element(by.id("uniqueId"))
 
 ## Instructions
 
-Your task is to generate the minimal executable code to perform the following intent: "tap button". In addition, inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add code lines that verify the existence of the elements that will be interacted with in this step. This is not required for all steps, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+Your task is to generate the minimal executable code to perform the following intent: "tap button".
 
 Please follow these steps carefully:
 
 1. Analyze the provided intent and the view hierarchy to understand the required action.
 2. Generate the minimal executable code required to perform the intent using the available API inside <CODE></CODE> block.
-3. Inside <CACHE_VALIDATION_MATCHER></CACHE_VALIDATION_MATCHER>, add the minimal executable code (1-2 lines) that verifies the existence of the elements that will be interacted with in this step, in the code part. This tag is not required, but it's important to add these lines as a safety measure to ensure that the test does not fail due to unexpected element not found errors.
+3. Include appropriate synchronization in your code using the testing framework's wait methods to ensure elements are present and ready before interacting with them. Use the testing framework's documented wait APIs to make the test more reliable and prevent flaky failures.
 4. If you cannot generate the relevant code due to ambiguity or invalid intent, return code that throws an informative error explaining the problem in one sentence.
 5. Each step must be completely independent - do not rely on any variables or assignments from previous steps. Even if a variable was declared or assigned in a previous step, you must redeclare and reassign it in your current step.
-6. Use the provided framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
+6. Use the provided the testing framework APIs as much as possible - prefer using the documented API methods over creating custom implementations.
 7. If you need to share data between steps, use the 'sharedContext' object. You can access and modify it directly like: sharedContext.myKey = 'myValue'
 8. Wrap the generated code with <CODE></CODE> block, without any additional formatting.
 9. Do not provide any additional code beyond the minimal executable code required to perform the intent.
@@ -1118,9 +1615,5 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of providing the validation matcher
-<CACHE_VALIDATION_MATCHER>
-const page = getCurrentPage(); const inputElement = await findElement(page, {placeholder: "Type the domain you want","aria-label": "Type the domain you want",class: "KvoMHf has-custom-focus wixui-text-input__input"}) ?? (() => { throw new Error('Input not found'); })();
-</CACHE_VALIDATION_MATCHER>
 Please provide your code below:"
 `;


### PR DESCRIPTION
Main Improvements
1. Conditional `CACHE_VALIDATION_MATCHER` Logic Problem: The `CACHE_VALIDATION_MATCHER` instructions were appearing in prompts even when no screenshot was attached Solution: Made `CACHE_VALIDATION_MATCHER` references conditional - they now only appear when isSnapshotImageAttached is true

2. Enhanced Synchronization Instructions Problem: No guidance on writing reliable test code with proper waiting mechanisms Solution: Added comprehensive instructions about including appropriate synchronization in generated test code

3. Framework-Specific References Problem: Generic references like "the testing framework" throughout the prompt Solution: Replaced all generic references with the actual framework name from this.apiCatalog.name

4. Improved API Section Naming Problem: API section title could be redundant when no framework name was provided Solution: Used proper ternary logic to show either "Available {FrameworkName} API" or "Available Testing Framework API"