### PR TITLE
fix: Improve `extractTaggedOutputs` 

### DIFF
--- a/packages/core/src/common/extract/extractTaggedOutputs.ts
+++ b/packages/core/src/common/extract/extractTaggedOutputs.ts
@@ -33,31 +33,33 @@ const PILOT_OUTPUTS = {
   code: { tag: "CODE", isRequired: true },
 };
 
-function extractTaggedOutputs<M extends OutputsMapping>({text, outputsMapper,}: {
-    text: string;
-    outputsMapper: M;
+function extractTaggedOutputs<M extends OutputsMapping>({
+  text,
+  outputsMapper,
+}: {
+  text: string;
+  outputsMapper: M;
 }): ExtractedType<M> {
-    const entries: [keyof M, string][] = [];
+  const entries: [keyof M, string | undefined][] = [];
 
-    for (const key of Object.keys(outputsMapper) as (keyof M)[]) {
-        const { tag, isRequired } = outputsMapper[key];
-        const regex = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`);
-        const match = text.match(regex);
+  for (const key of Object.keys(outputsMapper) as (keyof M)[]) {
+    const { tag, isRequired } = outputsMapper[key];
+    const regex = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`);
+    const match = text.match(regex);
 
-        if (match) {
-            const content = match[1].trim();
-            entries.push([key, content]);
-            text = text.replace(match[0], "");
-        } else if (!isRequired) {
-            entries.push([key, ""]);
-        } else {
-            throw new Error(`Missing field for required tag <${tag}>`);
-        }
+    if (match) {
+      const content = match[1].trim();
+      entries.push([key, content]);
+      text = text.replace(match[0], "");
+    } else if (!isRequired) {
+      entries.push([key, undefined]);
+    } else {
+      throw new Error(`Missing field for required tag <${tag}>`);
     }
+  }
 
-    return Object.fromEntries(entries) as ExtractedType<M>;
+  return Object.fromEntries(entries) as ExtractedType<M>;
 }
-
 
 /**
  * Extracts review outputs (summary, findings, score) from text with review tags

--- a/packages/core/src/integration-tests/__snapshots__/index.test.ts.snap
+++ b/packages/core/src/integration-tests/__snapshots__/index.test.ts.snap
@@ -76,7 +76,7 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of correct output format with both code and validation matcher:
+#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.
 
 **Main executable code:**
 <CODE>

--- a/packages/core/src/performers/step-performer/StepPerformerPromptCreator.ts
+++ b/packages/core/src/performers/step-performer/StepPerformerPromptCreator.ts
@@ -216,7 +216,7 @@ export class StepPerformerPromptCreator {
 
     if (isSnapshotImageAttached) {
       instructions.push(
-        "#### Example of correct output format with both code and validation matcher:",
+        "#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.",
         "",
         "**Main executable code:**",
         "<CODE>",

--- a/packages/core/src/performers/step-performer/__snapshots__/StepPerformerPromptCreator.test.ts.snap
+++ b/packages/core/src/performers/step-performer/__snapshots__/StepPerformerPromptCreator.test.ts.snap
@@ -240,7 +240,7 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of correct output format with both code and validation matcher:
+#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.
 
 **Main executable code:**
 <CODE>
@@ -384,7 +384,7 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of correct output format with both code and validation matcher:
+#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.
 
 **Main executable code:**
 <CODE>
@@ -534,7 +534,7 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of correct output format with both code and validation matcher:
+#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.
 
 **Main executable code:**
 <CODE>
@@ -1109,7 +1109,7 @@ Before generating the code, please review the provided context and instructions 
 throw new Error("Unable to find the 'Submit' button element in the current context.");
 </CODE>
 
-#### Example of correct output format with both code and validation matcher:
+#### Example of correct output format with both code and validation matcher. Do **not** nest one tag inside another. Each tagged block must be separate and self-contained.
 
 **Main executable code:**
 <CODE>


### PR DESCRIPTION
Correctly handle cases where `cacheValidationMatcher` is nested inside `code.`